### PR TITLE
Add arm64 installer

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -11,6 +11,12 @@ on:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+        - x64
+        - arm64
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -32,11 +38,11 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal Lanpartyseating.Desktop.Tests --configuration Release
     - name: Build
-      run: dotnet build LanpartySeating.Desktop.Installer/LanpartySeating.Desktop.Installer.wixproj --configuration Release --property:Version=1.0.20
+      run: dotnet build LanpartySeating.Desktop.Installer/LanpartySeating.Desktop.Installer.wixproj --configuration Release --property:Version=1.0.21 /p:InstallerPlatform=${{ matrix.arch }}
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: LanpartySeating.Desktop.Installer
+        name: LanpartySeating.Desktop.Installer (${{ matrix.arch }})
         path: |
-          LanpartySeating.Desktop.Installer/bin/Release/LanpartySeating.Desktop.Installer.msi
-          LanpartySeating.Desktop.Installer/bin/Release/LanpartySeating.Desktop.Installer.wixpdb
+          LanpartySeating.Desktop.Installer/bin/Release/LanpartySeating.Desktop.Installer-${{ matrix.arch }}.msi
+          LanpartySeating.Desktop.Installer/bin/Release/LanpartySeating.Desktop.Installer-${{ matrix.arch }}.wixpdb

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Cache NuGet packages
       uses: actions/cache@v3
       with:

--- a/LanpartySeating.Desktop.Installer/Lanpartyseating.Desktop.Installer.wixproj
+++ b/LanpartySeating.Desktop.Installer/Lanpartyseating.Desktop.Installer.wixproj
@@ -1,27 +1,32 @@
-﻿<Project Sdk="WixToolset.Sdk/4.0.2">
+﻿<Project Sdk="WixToolset.Sdk/4.0.3">
     <PropertyGroup>
         <!-- Default to Version 1.0.0 if not specified via /p:Version=x.x.x from cli -->
         <Version Condition=" '$(Version)' == '' ">1.0.0</Version>
         <!-- Propagate version information from msbuild to the WiX project -->
-        <DefineConstants>$(DefineConstants);Version=$(Version)</DefineConstants>
+        <DefineConstants>$(DefineConstants);Version=$(Version);PublishOutput=..\Lanpartyseating.Desktop\bin\$(Configuration)\net8.0-windows\win-$(InstallerPlatform)\publish</DefineConstants>
         <OutputType>package</OutputType>
-        <TargetFramework>net7.0-windows</TargetFramework>
-        <InstallerPlatform>x64</InstallerPlatform>
+        <TargetFramework>net8.0-windows</TargetFramework>
+        <!-- Default to x64 if not specified via /p:InstallerPlatform=x64 or /p:InstallerPlatform=arm64 from cli -->
+        <InstallerPlatform Condition=" '$(InstallerPlatform)' == '' ">x64</InstallerPlatform>
+        <OutputName>LanpartySeating.Desktop.Installer-$(InstallerPlatform)</OutputName>
     </PropertyGroup>
     <ItemGroup>
-        <HarvestDirectory Include="..\Lanpartyseating.Desktop\bin\$(Configuration)\net7.0-windows\">
+        <HarvestDirectory Include="..\Lanpartyseating.Desktop\bin\$(Configuration)\net8.0-windows\win-$(InstallerPlatform)\publish\">
             <DirectoryRefId>INSTALLFOLDER</DirectoryRefId>
             <ComponentGroupName>ApplicationFilesComponentGroup</ComponentGroupName>
             <KeepEmptyDirectories>true</KeepEmptyDirectories>
             <SuppressRootDirectory>true</SuppressRootDirectory>
             <Transforms>ExcludeFiles.xslt</Transforms>
+            <PreprocessorVariable>var.PublishOutput</PreprocessorVariable>
         </HarvestDirectory>
     </ItemGroup>
+    <Target Name="CustomBeforeBuild" BeforeTargets="BeforeBuild">
+        <Message Text="BeforeBuild is running" Importance="high" />
+        <Message Text="InstallerPlatform is $(InstallerPlatform)" Importance="high" />
+        <Exec Command="dotnet publish ..\Lanpartyseating.Desktop\Lanpartyseating.Desktop.csproj -c Release -r win-$(InstallerPlatform) -o ..\Lanpartyseating.Desktop\bin\$(Configuration)\net8.0-windows\win-$(InstallerPlatform)\publish\" />
+    </Target>
     <ItemGroup>
-        <ProjectReference Include="..\Lanpartyseating.Desktop\Lanpartyseating.Desktop.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="WixToolset.Heat" Version="4.0.2" />
-        <PackageReference Include="WixToolset.Util.wixext" Version="4.0.2" />
+        <PackageReference Include="WixToolset.Heat" Version="4.0.3" />
+        <PackageReference Include="WixToolset.Util.wixext" Version="4.0.3" />
     </ItemGroup>
 </Project>

--- a/LanpartySeating.Desktop.Installer/Lanpartyseating.Desktop.Installer.wxs
+++ b/LanpartySeating.Desktop.Installer/Lanpartyseating.Desktop.Installer.wxs
@@ -66,7 +66,7 @@
             <!-- Create a single component which is the Lanpartyseating.Desktop.exe file -->
             <Component Id="ServiceExecutable" Bitness="always64" Guid="3bcec0f5-8bfa-4fd0-98e8-2ebe0371efa4">
 
-                <File Source="..\Lanpartyseating.Desktop\bin\$(Configuration)\net7.0-windows\Lanpartyseating.Desktop.exe" />
+                <File Source="..\Lanpartyseating.Desktop\bin\$(Configuration)\net8.0-windows\win-$(InstallerPlatform)\publish\Lanpartyseating.Desktop.exe" />
                 
                 <!-- Remove all files from the INSTALLFOLDER on uninstall -->
                 <RemoveFile Id="ALLFILES" Name="*.*" On="both" />

--- a/Lanpartyseating.Desktop.Tests/Lanpartyseating.Desktop.Tests.csproj
+++ b/Lanpartyseating.Desktop.Tests/Lanpartyseating.Desktop.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/Lanpartyseating.Desktop.sln.DotSettings.user
+++ b/Lanpartyseating.Desktop.sln.DotSettings.user
@@ -1,11 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=10ba09a3_002D1640_002D4bef_002Db3c4_002D8eaf8e690b9b/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test_When_ForThisStationCalled_Then_MatchingStationNumberAndHostnameReturnTrue" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::8B549C98-F78C-422A-8C26-E1D7A0881CAD::net7.0-windows::Lanpartyseating.Desktop.Tests.UtilsTests.Test_When_ForThisStationCalled_Then_MatchingStationNumberAndHostnameReturnTrue&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::8B549C98-F78C-422A-8C26-E1D7A0881CAD::net8.0-windows::Lanpartyseating.Desktop.Tests.UtilsTests.Test_When_ForThisStationCalled_Then_MatchingStationNumberAndHostnameReturnTrue&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=27b22507_002D9043_002D43f5_002D9688_002Df4a293a50701/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Test_When_ForThisStationCalled_Then_MatchingStationNumberAndHostnameReturnTrue #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::8B549C98-F78C-422A-8C26-E1D7A0881CAD::net7.0-windows::Lanpartyseating.Desktop.Tests.UtilsTests.Test_When_ForThisStationCalled_Then_MatchingStationNumberAndHostnameReturnTrue&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::8B549C98-F78C-422A-8C26-E1D7A0881CAD::net8.0-windows::Lanpartyseating.Desktop.Tests.UtilsTests.Test_When_ForThisStationCalled_Then_MatchingStationNumberAndHostnameReturnTrue&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/Lanpartyseating.Desktop/Lanpartyseating.Desktop.csproj
+++ b/Lanpartyseating.Desktop/Lanpartyseating.Desktop.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />
-      <PackageReference Include="System.Management" Version="7.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+      <PackageReference Include="System.Management" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -27,7 +26,4 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>
-
-
-
 </Project>


### PR DESCRIPTION
This PR introduces multi-arch installer support. Realistically, this application will be used on the x64 architecture 99% of the time and 100% of the time in production. However, I've found myself developing this application in an ARM64 Windows virtual machine on an Apple Silicon macbook. It doesn't cost much to add this support so let's go for it!