### PR TITLE
Don't show login dialog outside game sessions

### DIFF
--- a/Lanpartyseating.Desktop.Tray/ToastNotificationService.cs
+++ b/Lanpartyseating.Desktop.Tray/ToastNotificationService.cs
@@ -114,6 +114,9 @@ public class ToastNotificationService : BackgroundService
         }
         else if (message is ReservationStateResponse reservationStateResponse)
         {
+            // Don't show the pop-up if the session is not active (e.g. tournament or fresh boot auto login)
+            if (reservationStateResponse.IsSessionActive == false) return;
+
             var minutesUntilEnd = (reservationStateResponse.ReservationEnd - DateTimeOffset.UtcNow).TotalMinutes;
             var formattedLocalEndTime = reservationStateResponse.ReservationEnd.ToLocalTime().ToString("t");
             


### PR DESCRIPTION
Only show the welcome dialog when logged into a game session, don't show it during tournament or other sessions with an invalid negative time value.

Fixes #16 