### PR TITLE
Fix named pipe server hosted service crash

### DIFF
--- a/Lanpartyseating.Desktop/Business/NamedPipeServerHostedService.cs
+++ b/Lanpartyseating.Desktop/Business/NamedPipeServerHostedService.cs
@@ -68,12 +68,11 @@ public class NamedPipeServerHostedService : BackgroundService, INamedPipeServerS
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            InitializePipeServer();
-
-            _logger.LogInformation("Waiting for client connection...");
-
             try
             {
+                InitializePipeServer();
+                _logger.LogInformation("Waiting for client connection...");
+
                 var waitTask = _server.WaitForConnectionAsync(stoppingToken);
                 var timeoutTask = Task.Delay(TimeSpan.FromSeconds(10), stoppingToken); // Adjust the timeout as needed
 
@@ -139,6 +138,8 @@ public class NamedPipeServerHostedService : BackgroundService, INamedPipeServerS
 
         if (pipeHandle.IsInvalid)
         {
+            // Access denied errors have been observed here intermittently.
+            // Throwing here will cause the server to re-initialize in the run loop above.
             throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 


### PR DESCRIPTION
Moves the named pipe server startup routine into the try/catch block that attempts to restart the hosted service if something goes wrong with the named pipe server. The initialization routine can throw, so it needs to be in the try/catch or it will take down the entire host.

Fixes #17 