### PR TITLE
Clear autologon credentials on session log-on

### DIFF
--- a/Lanpartyseating.Desktop.Abstractions/BaseMessage.cs
+++ b/Lanpartyseating.Desktop.Abstractions/BaseMessage.cs
@@ -4,6 +4,7 @@ namespace Lanpartyseating.Desktop.Abstractions;
 
 [JsonDerivedType(typeof(ReservationStateRequest), typeDiscriminator: "sessionstaterequest")]
 [JsonDerivedType(typeof(ReservationStateResponse), typeDiscriminator: "sessionstateresponse")]
+[JsonDerivedType(typeof(ClearAutoLogonRequest), typeDiscriminator: "clearautologonrequest")]
 [JsonDerivedType(typeof(TextMessage), typeDiscriminator: "textmessage")]
 public abstract class BaseMessage
 {

--- a/Lanpartyseating.Desktop.Abstractions/ClearAutoLogonRequest.cs
+++ b/Lanpartyseating.Desktop.Abstractions/ClearAutoLogonRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace Lanpartyseating.Desktop.Abstractions;
+
+public class ClearAutoLogonRequest : BaseMessage
+{
+}

--- a/Lanpartyseating.Desktop.Tray/ToastNotificationService.cs
+++ b/Lanpartyseating.Desktop.Tray/ToastNotificationService.cs
@@ -70,9 +70,12 @@ public class ToastNotificationService : BackgroundService
     private async Task SendInitialMessageAsync(NamedPipeClientStream client, CancellationToken stoppingToken)
     {
         await using var writer = new StreamWriter(client, leaveOpen: true);
-        var request = new ReservationStateRequest();
-        var jsonRequest = JsonMessageSerializer.Serialize(request);
-        await writer.WriteLineAsync(jsonRequest);
+        var reservationStateRequest = new ReservationStateRequest();
+        var jsonReservationStateRequest = JsonMessageSerializer.Serialize(reservationStateRequest);
+        var clearAutoLogonRequest = new ClearAutoLogonRequest();
+        var jsonClearAutoLogonRequest = JsonMessageSerializer.Serialize(clearAutoLogonRequest);
+        await writer.WriteLineAsync(jsonReservationStateRequest);
+        await writer.WriteLineAsync(jsonClearAutoLogonRequest);
         await writer.FlushAsync(stoppingToken);
     }
 

--- a/Lanpartyseating.Desktop/Business/DummySessionManager.cs
+++ b/Lanpartyseating.Desktop/Business/DummySessionManager.cs
@@ -26,4 +26,9 @@ public class DummySessionManager : ISessionManager
     {
         _logger.LogInformation("The client would have logged out an the current interactive session now");
     }
+
+    public void ClearAutoLogonCredentials()
+    {
+        _logger.LogInformation("The client would have cleared the autologon credentials now");
+    }
 }

--- a/Lanpartyseating.Desktop/Business/ISessionManager.cs
+++ b/Lanpartyseating.Desktop/Business/ISessionManager.cs
@@ -5,4 +5,5 @@ public interface ISessionManager
     public void SignInGamerAccount();
     public void SignInTournamentAccount();
     public void SignOut();
+    public void ClearAutoLogonCredentials();
 }

--- a/Lanpartyseating.Desktop/Business/NamedPipeServerHostedService.cs
+++ b/Lanpartyseating.Desktop/Business/NamedPipeServerHostedService.cs
@@ -15,13 +15,15 @@ public class NamedPipeServerHostedService : BackgroundService, INamedPipeServerS
 {
     private readonly ILogger<NamedPipeServerHostedService> _logger;
     private readonly ReservationManager _reservationManager;
+    private readonly ISessionManager _sessionManager;
     private const string PipeName = "Lanpartyseating.Desktop";
     private NamedPipeServerStream? _server;
 
-    public NamedPipeServerHostedService(ILogger<NamedPipeServerHostedService> logger, ReservationManager reservationManager)
+    public NamedPipeServerHostedService(ILogger<NamedPipeServerHostedService> logger, ReservationManager reservationManager, ISessionManager sessionManager)
     {
         _logger = logger;
         _reservationManager = reservationManager;
+        _sessionManager = sessionManager;
         _server = null;
     }
     
@@ -195,6 +197,14 @@ public class NamedPipeServerHostedService : BackgroundService, INamedPipeServerS
                         };
                         await writer.WriteLineAsync(JsonMessageSerializer.Serialize(response));
                         await writer.FlushAsync();
+                    }
+                    else if (baseMessage is ClearAutoLogonRequest)
+                    {
+                        _sessionManager.ClearAutoLogonCredentials();
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Received an unknown message type.");
                     }
 
                     // Check for cancellation again after processing the message

--- a/Lanpartyseating.Desktop/Business/WindowsSessionManager.cs
+++ b/Lanpartyseating.Desktop/Business/WindowsSessionManager.cs
@@ -69,4 +69,18 @@ public class WindowsSessionManager : ISessionManager
         var sessionId = WTSGetActiveConsoleSessionId();
         WTSLogoffSession(IntPtr.Zero, sessionId, false);
     }
+
+    public void ClearAutoLogonCredentials()
+    {
+        var winlogonRegPath = @"Software\Microsoft\Windows NT\CurrentVersion\Winlogon";
+
+        // Disable autologon
+        Registry.SetValue($@"HKEY_LOCAL_MACHINE\{winlogonRegPath}", "AutoAdminLogon", 0, RegistryValueKind.DWord);
+
+        // Clear autologon username
+        Registry.SetValue($@"HKEY_LOCAL_MACHINE\{winlogonRegPath}", "DefaultUserName", "", RegistryValueKind.String);
+
+        // Clear autologon password
+        Registry.SetValue($@"HKEY_LOCAL_MACHINE\{winlogonRegPath}", "DefaultPassword", "", RegistryValueKind.String);
+    }
 }


### PR DESCRIPTION
The method we use to auto log-in the gamer and tournament accounts is a huge hack that relies on a side-effect we introduce in the windows registry, altering the behaviour of winlogon. Up until now, the credentials were never cleared and only upserted when logging in new sessions.

This PR introduces a new message type the tray application can send to the service over the named pipe to instruct the service to clear the autologon credentials in the registry. Currently, this will be performed on launch of the tray app (i.e. once an interactive session logs in). This is a sensible default that will make sure the credentials are cleaned up pretty much as soon as possible. The only downside to this compared to the previous behaviour is that if a computer is rebooted during a play session, it will not auto-login again and resume the play session. This was never intended functionality and just a happy side-effect of the previous implementation. We could restore this behaviour by clearing the credentials only at the end of the session but I think this would be less reliable and prone to glitching.

Fixes #15 